### PR TITLE
feat: gateway-manager: split adding of tenant out from generic setup

### DIFF
--- a/src/gateway-manager/templates/add-tenant.yaml
+++ b/src/gateway-manager/templates/add-tenant.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: aether-initialize
+  name: aether-add-tenant
 data:
-    initialize.sh: |
+    add-tenant.sh: |
         #!/usr/bin/env bash
         #
         # Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
@@ -33,16 +33,41 @@ data:
         # - DB running
         # - Kong running
         # - Keycloak running
-
-        echo "Performing basic Gateway setup"
-        $AUTH_RUN setup_auth
-
-        # TODO -- Add when Kafka is ready
-
-        # REQUIRES ( additionally ):
-        # - Zookeeper running
-        # - Kafka running
         
-        # echo "Creating Kafka Superuser..."
-        # $AUTH_RUN add_kafka_su $KAFKA_SU_USER $KAFKA_SU_PASSWORD
-        # $AUTH_RUN grant_kafka_su $KAFKA_ROOT_USER
+
+        function create_tenant {
+            REALM=$1
+            DESC=${2:-$REALM}
+
+            $AUTH_RUN add_realm \
+                $REALM \
+                "$DESC" \
+                $LOGIN_THEME
+
+            $AUTH_RUN add_public_client \
+                $REALM \
+                $KEYCLOAK_AETHER_CLIENT
+
+            $AUTH_RUN add_oidc_client \
+                $REALM \
+                $KEYCLOAK_KONG_CLIENT
+
+            $AUTH_RUN add_user \
+                $REALM \
+                $KEYCLOAK_INITIAL_USER_USERNAME \
+                $KEYCLOAK_INITIAL_USER_PASSWORD
+
+            $AUTH_RUN add_solution aether $REALM $KEYCLOAK_KONG_CLIENT
+
+            # TODO Add when Kafka is ready
+
+            # REQUIRES ( additionally ):
+            # - Zookeeper running
+            # - Kafka running
+
+            # $AUTH_RUN add_kafka_tenant $REALM
+        }
+
+
+        echo "Creating tenant: {{ .Values.gw.env }}..."
+        create_tenant  "{{ .Values.gw.env }}"  "{{ .Values.gw.env }} instance"

--- a/src/gateway-manager/templates/job.yaml
+++ b/src/gateway-manager/templates/job.yaml
@@ -40,8 +40,18 @@ spec:
           value: {{ .Values.gw.baseHost }}
         - name: KEYCLOAK_INTERNAL
           value: {{ .Values.gw.keyCloak.internalService }}
+        - name: KEYCLOAK_INITIAL_USER_USERNAME
+          value: {{ .Values.gw.keyCloak.initial_user }}
+        - name: KEYCLOAK_INITIAL_USER_PASSWORD
+          value: {{.Values.gw.keyCloak.initial_password}}
         - name: KONG_INTERNAL
           value: {{ .Values.gw.kong.internalService }}
+        - name: KAFKA_SU_USER
+          value: {{ .Values.gw.kafka.kafkaSUUser }}
+        - name: KAFKA_SU_PASSWORD
+          value: {{ .Values.gw.kafka.kafkaSUPassword }}
+        - name: KAFKA_ROOT_USER
+          value: {{ .Values.gw.kafka.kafkaRootUser }}
         volumeMounts:
         - name: aether-services
           mountPath: /code/service

--- a/src/gateway-manager/values.yaml
+++ b/src/gateway-manager/values.yaml
@@ -18,10 +18,16 @@ gw:
       internalService: ''
   keyCloak:
     globalAdmin: 'keycloak'
-    kongClient: ''
+    kongClient: 'kong'
     aetherClient: 'aether' 
     baseDomain: ''
     baseHost: ''
     internalService: ''
+    initial_user: 'user'
+    initial_password: 'password'
+  kafka:
+    kafkaSUUser: ''
+    kafkaSUPassword: ''
+    kafkaRootUser: ''
   kong:
     internalService: ''


### PR DESCRIPTION
Split scripts that setup gateway vs. add a tenant. Added placeholders for Kafka credentials.