### PR TITLE
Add extra routes to the hosts definition to allow a sub-path be routed to a different service.

### DIFF
--- a/src/generic/Chart.yaml
+++ b/src/generic/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Generic Helm chart for Kubernetes
 name: generic
-version: 0.3.0
+version: 0.4.0

--- a/src/generic/templates/ingress.yaml
+++ b/src/generic/templates/ingress.yaml
@@ -17,20 +17,26 @@ metadata:
 spec:
   tls:
   - hosts:
-    {{- range .Values.ingress.hosts }}
-    - {{ . }}
+    {{- range $host := .Values.ingress.hosts }}
+    - {{ $host.name }}
     {{- end }}
     {{ if .Values.ingress.ssl.letsencrypt }}
     secretName: {{ .Values.ingress.ssl.cert_secret }}
     {{ end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host.name }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- range $route := $host.extra_routes }}
+          - path: {{ $route.path }}
+            backend:
+              serviceName: {{ $route.serviceName }}
+              servicePort: {{ $route.servicePort }}
+          {{- end -}}
     {{- end -}}
 {{ end }}


### PR DESCRIPTION
Note: this is a breaking change that requires you to change the definition in your override file

Example:

ingress:
  enabled: true
  hosts:
    - name: vts.eha.im
      extra_routes:
        - path: /geoserver
          serviceName: vts-geoserver
          servicePort: 8090